### PR TITLE
Fix invalid block tag "static" in base.html

### DIFF
--- a/project_name/templates/base.html
+++ b/project_name/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype HTML>
 {% load compress %}
-{% load static %}
+{% load staticfiles %}
 {% load fusionbox_tags %}
 <html>
   <head>


### PR DESCRIPTION
Any reason this wasn't in here? It was causing template errors for me.
