### PR TITLE
Must assign database url config to 'default' key in dict

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -13,7 +13,7 @@ MANAGERS = ADMINS
 
 # Parse database configuration from $DATABASE_URL
 import dj_database_url
-DATABASES = dj_database_url.config(default='sqlite:///sqlite_database')
+DATABASES = {'default': dj_database_url.config(default='sqlite:///sqlite_database')}
 
 TIME_ZONE = 'America/Denver'
 SITE_ID = 1


### PR DESCRIPTION
Assigning it directly to the `DATABASES` config settings causes a `KeyError` when the following code is run:

``` python
DATABASE_ENGINE = DATABASES['default']['ENGINE']
```
