### PR TITLE
New debug_toolbar imports and patches urls

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -228,3 +228,7 @@ try:
     SENTRY_DSN = os.environ['SENTRY_DSN']
 except KeyError:
     pass
+
+# New version of django-debug-toolbar attempts to patch settings
+# and urls without this setting
+DEBUG_TOOLBAR_PATCH_SETTINGS = False

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -6,6 +6,8 @@ admin.autodiscover()
 
 from django.conf import settings
 
+import debug_toolbar
+
 urlpatterns = patterns('',
     url('^robots.txt$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     # url('^sitemap.xml$', TemplateView.as_view(template_name='sitemap.xml', content_type='application/xml'),
@@ -25,3 +27,8 @@ if settings.DEBUG:
             'document_root': settings.MEDIA_ROOT,
         }),
     )
+
+    if debug_toolbar.VERSION > '1.2.0':
+        urlpatterns += patterns('',
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        )


### PR DESCRIPTION
In order to avoid circular imports, debug_toolbar requires an
explicit setting to be declared and urls to be patched manually.
