### PR TITLE
In preparation for use with Django 1.7

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -99,7 +99,6 @@ INSTALLED_APPS = (
     # 3rd party
     'compressor',
     'cachebuster',
-    'south',
     'debug_toolbar',
     'fusionbox.core',
     'django_extensions',
@@ -228,7 +227,3 @@ try:
     SENTRY_DSN = os.environ['SENTRY_DSN']
 except KeyError:
     pass
-
-# New version of django-debug-toolbar attempts to patch settings
-# and urls without this setting
-DEBUG_TOOLBAR_PATCH_SETTINGS = False

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import patterns, include, url
 from django.views.generic import TemplateView
 
 from django.contrib import admin
-admin.autodiscover()
 
 from django.conf import settings
 
@@ -27,8 +26,3 @@ if settings.DEBUG:
             'document_root': settings.MEDIA_ROOT,
         }),
     )
-
-    if debug_toolbar.VERSION > '1.2.0':
-        urlpatterns += patterns('',
-            url(r'^__debug__/', include(debug_toolbar.urls)),
-        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -e git://github.com/fusionbox/django-fusionbox.git#egg=django_fusionbox
 Django
-South
 Werkzeug
 django-cachebuster
 django-compressor


### PR DESCRIPTION
Django 1.7 comes with migrations, enables autodiscover by default,
and gets along with the debug_toolbar automatic urlconf patching.
