### PR TITLE
Deactivate languages selector on admin login

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -20,7 +20,7 @@ TIME_ZONE = 'America/Denver'
 SITE_ID = 1
 USE_L10N = True
 USE_TZ = True
-
+LANGUAGES = []
 # Set Sorl Thumbnailer to png to preserve transparent backgrounds
 THUMBNAIL_FORMAT = 'PNG'
 


### PR DESCRIPTION
Most projects don't use the language selector of the admin login, I think it could be a good idea to deactivate it by default.